### PR TITLE
Remove Display for TextSize

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -37,7 +37,7 @@ pub struct TextRange {
 
 impl fmt::Debug for TextRange {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "[{}..{})", self.start(), self.end())
+        write!(f, "[{}..{})", self.start().raw, self.end().raw)
     }
 }
 

--- a/src/size.rs
+++ b/src/size.rs
@@ -32,13 +32,7 @@ pub(crate) const fn TextSize(raw: u32) -> TextSize {
 
 impl fmt::Debug for TextSize {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(self, f)
-    }
-}
-
-impl fmt::Display for TextSize {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self.raw, f)
+        write!(f, "{}", self.raw)
     }
 }
 


### PR DESCRIPTION
We removed the `Display` impl for `TextRange`, we should at least consider removing it for `TextSize` as well.