### PR TITLE
Switch to mathematical range notation

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -37,7 +37,7 @@ pub struct TextRange {
 
 impl fmt::Debug for TextRange {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "[{}..{})", self.start().raw, self.end().raw)
+        write!(f, "{}..{}", self.start().raw, self.end().raw)
     }
 }
 


### PR DESCRIPTION
Just an option: `[10..20)` feel like a weird mix of rust and math. `[10, 20)` is just picking the math notation. 