### PR TITLE
Add to_usize

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -127,20 +127,16 @@ impl TextRange {
     }
 }
 
-fn ix(size: TextSize) -> usize {
-    size.into()
-}
-
 impl Index<TextRange> for str {
     type Output = str;
     fn index(&self, index: TextRange) -> &Self::Output {
-        &self[ix(index.start())..ix(index.end())]
+        &self[index.start().to_usize()..index.end().to_usize()]
     }
 }
 
 impl IndexMut<TextRange> for str {
     fn index_mut(&mut self, index: TextRange) -> &mut Self::Output {
-        &mut self[ix(index.start())..ix(index.end())]
+        &mut self[index.start().to_usize()..index.end().to_usize()]
     }
 }
 

--- a/src/size.rs
+++ b/src/size.rs
@@ -49,6 +49,16 @@ impl TextSize {
     pub const fn zero() -> TextSize {
         TextSize(0)
     }
+
+    /// Cast to `usize`.
+    pub const fn to_usize(self) -> usize {
+        assert_lossless_conversion();
+        return self.raw as usize;
+
+        const fn assert_lossless_conversion() {
+            [()][(std::mem::size_of::<usize>() < std::mem::size_of::<u32>()) as usize]
+        }
+    }
 }
 
 /// Methods to act like a primitive integer type, where reasonably applicable.
@@ -91,12 +101,7 @@ impl TryFrom<usize> for TextSize {
 
 impl From<TextSize> for usize {
     fn from(value: TextSize) -> Self {
-        assert_lossless_conversion();
-        return value.raw as usize;
-
-        const fn assert_lossless_conversion() {
-            [()][(std::mem::size_of::<usize>() < std::mem::size_of::<u32>()) as usize]
-        }
+        value.to_usize()
     }
 }
 


### PR DESCRIPTION
The main benefit of `.to_usize` versus `.into()` is that the type is
fixed for the purposes of type-inference. This is handly if you want
to do `"hello, world"[..ts.to_usize()]`.

To clarify, the only reason why we might want this function is because `"hello, world"[..ts]` doesn't work, because of perma-unstable indexing trait in std :(