### PR TITLE
Alternative set of contains function

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -88,8 +88,23 @@ impl TextRange {
 
 /// Manipulation methods.
 impl TextRange {
+    /// Check if this range contains an offset.
+    ///
+    /// The end index is considered excluded.
+    pub fn contains(self, offset: TextSize) -> bool {
+        self.start() <= offset && offset < self.end()
+    }
+
+    /// Check if this range contains an offset.
+    ///
+    /// The end index is considered included.
+    pub fn contains_inclusive(self, offset: TextSize) -> bool {
+        let point = offset.into();
+        self.start() <= point && point <= self.end()
+    }
+
     /// Check if this range completely contains another range.
-    pub fn contains(self, other: TextRange) -> bool {
+    pub fn contains_range(self, other: TextRange) -> bool {
         self.start() <= other.start() && other.end() <= self.end()
     }
 
@@ -109,21 +124,6 @@ impl TextRange {
         let start = cmp::min(lhs.start(), rhs.start());
         let end = cmp::max(lhs.end(), rhs.end());
         TextRange(start, end)
-    }
-
-    /// Check if this range contains an offset.
-    ///
-    /// The end index is considered excluded.
-    pub fn contains_exclusive(self, offset: TextSize) -> bool {
-        self.start() <= offset && offset < self.end()
-    }
-
-    /// Check if this range contains an offset.
-    ///
-    /// The end index is considered included.
-    pub fn contains_inclusive(self, offset: TextSize) -> bool {
-        let point = offset.into();
-        self.start() <= point && point <= self.end()
     }
 }
 

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -32,8 +32,8 @@ fn checked_math() {
 #[test]
 #[rustfmt::skip]
 fn contains() {
-    assert!(   range(2..4).contains(range(2..3)));
-    assert!( ! range(2..4).contains(range(1..3)));
+    assert!(   range(2..4).contains_range(range(2..3)));
+    assert!( ! range(2..4).contains_range(range(1..3)));
 }
 
 #[test]
@@ -59,11 +59,11 @@ fn covering() {
 #[test]
 #[rustfmt::skip]
 fn contains_point() {
-    assert!( ! range(1..3).contains_exclusive(size(0)));
-    assert!(   range(1..3).contains_exclusive(size(1)));
-    assert!(   range(1..3).contains_exclusive(size(2)));
-    assert!( ! range(1..3).contains_exclusive(size(3)));
-    assert!( ! range(1..3).contains_exclusive(size(4)));
+    assert!( ! range(1..3).contains(size(0)));
+    assert!(   range(1..3).contains(size(1)));
+    assert!(   range(1..3).contains(size(2)));
+    assert!( ! range(1..3).contains(size(3)));
+    assert!( ! range(1..3).contains(size(4)));
 
     assert!( ! range(1..3).contains_inclusive(size(0)));
     assert!(   range(1..3).contains_inclusive(size(1)));


### PR DESCRIPTION
Motivation:

TextRange is a set, it contains elements (TextSize). For this reason,
for range-range op we use a more verbose `contains_range` name.

In stdlib, there's `HashSet::is_subset`. We used a similar design with
`is_subrage` before, but it was very confusing in practice -- you'll
have to lookup docs for which of lhs and rhs is sub and super set.

Additionally, exclusive semantics is a clear default with better
properties (if you have a partitioning of a range into subranges, only
one of the parts contains any given offset), so it make sense to call
it `contains` and reserve `contains_inclusive` for another op.