### PR TITLE
Minimal change for unbounded ranges

### DIFF
--- a/src/size.rs
+++ b/src/size.rs
@@ -32,7 +32,10 @@ pub(crate) const fn TextSize(raw: u32) -> TextSize {
 
 impl fmt::Debug for TextSize {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.raw)
+        match self.raw {
+            u32::MAX => write!(f, "∞"),
+            raw => write!(f, "{}", raw),
+        }
     }
 }
 
@@ -49,6 +52,11 @@ impl TextSize {
     pub const fn zero() -> TextSize {
         TextSize(0)
     }
+
+    /// A size of one.
+    pub const fn one() -> TextSize {
+        TextSize(1)
+    }
 }
 
 /// Methods to act like a primitive integer type, where reasonably applicable.
@@ -56,12 +64,14 @@ impl TextSize {
 impl TextSize {
     /// The smallest representable text size. (`u32::MIN`)
     pub const MIN: TextSize = TextSize(u32::MIN);
-    /// The largest representable text size. (`u32::MAX`)
-    pub const MAX: TextSize = TextSize(u32::MAX);
+    /// The largest representable text size. (`u32::MAX - 1`)
+    pub const MAX: TextSize = TextSize(u32::MAX - 1);
+    /// An infinite, unbounded text size, larger than `TextSize::MAX`.
+    pub const INF: TextSize = TextSize(u32::MAX);
 
     #[allow(missing_docs)]
-    pub fn checked_add(self, rhs: TextSize) -> Option<TextSize> {
-        self.raw.checked_add(rhs.raw).map(TextSize)
+    pub fn saturating_add(self, rhs: TextSize) -> TextSize {
+        TextSize(self.raw.saturating_add(rhs.raw))
     }
 
     #[allow(missing_docs)]
@@ -70,12 +80,14 @@ impl TextSize {
     }
 }
 
+// now questionable
 impl From<u32> for TextSize {
     fn from(raw: u32) -> Self {
         TextSize { raw }
     }
 }
 
+// now questionable
 impl From<TextSize> for u32 {
     fn from(value: TextSize) -> Self {
         value.raw
@@ -85,10 +97,12 @@ impl From<TextSize> for u32 {
 impl TryFrom<usize> for TextSize {
     type Error = TryFromIntError;
     fn try_from(value: usize) -> Result<Self, TryFromIntError> {
+        // now questionable
         Ok(u32::try_from(value)?.into())
     }
 }
 
+// now questionable
 impl From<TextSize> for usize {
     fn from(value: TextSize) -> Self {
         assert_lossless_conversion();

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -23,10 +23,11 @@ fn math() {
 
 #[test]
 fn checked_math() {
-    assert_eq!(size(1).checked_add(size(1)), Some(size(2)));
+    // assert_eq!(size(1).checked_add(size(1)), Some(size(2)));
     assert_eq!(size(1).checked_sub(size(1)), Some(size(0)));
     assert_eq!(size(1).checked_sub(size(2)), None);
-    assert_eq!(TextSize::MAX.checked_add(size(1)), None);
+    assert_eq!(TextSize::MAX.saturating_add(size(1)), TextSize::INF);
+    assert_eq!(TextSize::INF.saturating_add(size(1)), TextSize::INF);
 }
 
 #[test]


### PR DESCRIPTION
Closes #15

This is what I believe to be the minimal diff to support right-unbounded ranges with `TextSize`/`TextRange`. `TextSize(u32::MAX)` is reserved to mean ∞/unbounded, and the only functions that outright need to be adjusted to respect those semantics are `checked_add` (just replaced with `saturating_add` for now), `len` (return `TextSize::INF` for unbounded ranges), and the actual indexing.

This added semantics to `TextSize` does make the following impls questionable, and deserving of a new fresh look:

- `From<u32> for TextSize`: `u32::MAX` is lossy
- `From<TextSize> for u32`: `TextSize::INF` is lossy
- `TryFrom<usize> for TextSize`: `u32::MAX` is lossy
- `From<TextSize> for u32`: `TextSize::INF` is lossy