### PR TITLE
minor improvements everywhere

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,6 @@ mod traits;
 mod serde_impls;
 
 pub use crate::{range::TextRange, size::TextSize, traits::TextSized};
+
+#[cfg(target_pointer_width = "16")]
+compile_error!("text-size assumes usize >= u32 and does not work on 16-bit targets");

--- a/src/range.rs
+++ b/src/range.rs
@@ -64,18 +64,6 @@ impl TextRange {
             end,
         }
     }
-
-    /// Offset this range by some amount.
-    ///
-    /// This is typically used to convert a range from one coordinate space to
-    /// another, such as from within a substring to within an entire document.
-    #[inline]
-    pub fn offset(self, offset: TextSize) -> TextRange {
-        TextRange(
-            self.start().checked_add(offset).unwrap(),
-            self.end().checked_add(offset).unwrap(),
-        )
-    }
 }
 
 /// Identity methods.

--- a/src/range.rs
+++ b/src/range.rs
@@ -11,7 +11,7 @@ use {
 /// # Translation from `text_unit`
 ///
 /// - `TextRange::from_to(from, to)`        ⟹ `TextRange(from, to)`
-/// - `TextRange::offset_len(offset, size)` ⟹ `TextRange::before(size).offset(offset)`
+/// - `TextRange::offset_len(offset, size)` ⟹ `TextRange::up_to(size).offset(offset)`
 /// - `range.start()`                       ⟹ `range.start()`
 /// - `range.end()`                         ⟹ `range.end()`
 /// - `range.len()`                         ⟹ `range.len()`
@@ -58,7 +58,7 @@ impl TextRange {
 
     /// Create a range up to the given end (`..end`).
     #[inline]
-    pub const fn before(end: TextSize) -> TextRange {
+    pub const fn up_to(end: TextSize) -> TextRange {
         TextRange {
             start: TextSize::zero(),
             end,

--- a/src/range.rs
+++ b/src/range.rs
@@ -40,6 +40,7 @@ impl fmt::Debug for TextRange {
 ///
 /// Panics if `end < start`.
 #[allow(non_snake_case)]
+#[inline]
 pub fn TextRange(start: TextSize, end: TextSize) -> TextRange {
     assert!(start <= end);
     TextRange { start, end }
@@ -47,6 +48,7 @@ pub fn TextRange(start: TextSize, end: TextSize) -> TextRange {
 
 impl TextRange {
     /// Create a zero-length range at the specified offset (`offset..offset`).
+    #[inline]
     pub const fn empty(offset: TextSize) -> TextRange {
         TextRange {
             start: offset,
@@ -55,6 +57,7 @@ impl TextRange {
     }
 
     /// Create a range up to the given end (`..end`).
+    #[inline]
     pub const fn before(end: TextSize) -> TextRange {
         TextRange {
             start: TextSize::zero(),
@@ -68,6 +71,7 @@ impl TextRange {
     /// `TextRange` does not support right-unbounded ranges. As such, this
     /// should only be used for direct indexing, and bounded ranges should be
     /// used for persistent ranges (`TextRange(start, TextSize::of(text))`).
+    #[inline]
     pub const fn after(start: TextSize) -> RangeFrom<usize> {
         start.raw as usize..
     }
@@ -76,6 +80,7 @@ impl TextRange {
     ///
     /// This is typically used to convert a range from one coordinate space to
     /// another, such as from within a substring to within an entire document.
+    #[inline]
     pub fn offset(self, offset: TextSize) -> TextRange {
         TextRange(
             self.start().checked_add(offset).unwrap(),
@@ -87,22 +92,26 @@ impl TextRange {
 /// Identity methods.
 impl TextRange {
     /// The start point of this range.
+    #[inline]
     pub const fn start(self) -> TextSize {
         self.start
     }
 
     /// The end point of this range.
+    #[inline]
     pub const fn end(self) -> TextSize {
         self.end
     }
 
     /// The size of this range.
+    #[inline]
     pub const fn len(self) -> TextSize {
         // HACK for const fn: math on primitives only
         TextSize(self.end().raw - self.start().raw)
     }
 
     /// Check if this range is empty.
+    #[inline]
     pub const fn is_empty(self) -> bool {
         // HACK for const fn: math on primitives only
         self.start().raw == self.end().raw
@@ -151,12 +160,14 @@ impl TextRange {
 
 impl Index<TextRange> for str {
     type Output = str;
+    #[inline]
     fn index(&self, index: TextRange) -> &Self::Output {
         &self[Range::<usize>::from(index)]
     }
 }
 
 impl IndexMut<TextRange> for str {
+    #[inline]
     fn index_mut(&mut self, index: TextRange) -> &mut Self::Output {
         &mut self[Range::<usize>::from(index)]
     }
@@ -176,6 +187,7 @@ impl<T> From<TextRange> for Range<T>
 where
     T: From<TextSize>,
 {
+    #[inline]
     fn from(r: TextRange) -> Self {
         r.start().into()..r.end().into()
     }

--- a/src/range.rs
+++ b/src/range.rs
@@ -2,7 +2,7 @@ use {
     crate::TextSize,
     std::{
         cmp, fmt,
-        ops::{Bound, Index, IndexMut, Range, RangeBounds, RangeFrom},
+        ops::{Bound, Index, IndexMut, Range, RangeBounds},
     },
 };
 

--- a/src/range.rs
+++ b/src/range.rs
@@ -11,7 +11,7 @@ use {
 /// # Translation from `text_unit`
 ///
 /// - `TextRange::from_to(from, to)`        ⟹ `TextRange(from, to)`
-/// - `TextRange::offset_len(offset, size)` ⟹ `TextRange::to(size).offset(offset)`
+/// - `TextRange::offset_len(offset, size)` ⟹ `TextRange::before(size).offset(offset)`
 /// - `range.start()`                       ⟹ `range.start()`
 /// - `range.end()`                         ⟹ `range.end()`
 /// - `range.len()`                         ⟹ `range.len()`
@@ -63,17 +63,6 @@ impl TextRange {
             start: TextSize::zero(),
             end,
         }
-    }
-
-    /// Create a range after the given start (`start..`).
-    ///
-    /// This returns a std [`RangeFrom`] rather than `TextRange` because
-    /// `TextRange` does not support right-unbounded ranges. As such, this
-    /// should only be used for direct indexing, and bounded ranges should be
-    /// used for persistent ranges (`TextRange(start, TextSize::of(text))`).
-    #[inline]
-    pub const fn after(start: TextSize) -> RangeFrom<usize> {
-        start.raw as usize..
     }
 
     /// Offset this range by some amount.

--- a/src/size.rs
+++ b/src/size.rs
@@ -46,6 +46,7 @@ impl fmt::Debug for TextSize {
 
 impl TextSize {
     /// The text size of some text-like object.
+    #[inline]
     pub fn of(text: impl TextSized) -> TextSize {
         text.text_size()
     }
@@ -54,11 +55,13 @@ impl TextSize {
     ///
     /// This is equivalent to `TextSize::default()` or [`TextSize::MIN`],
     /// but is more explicit on intent.
+    #[inline]
     pub const fn zero() -> TextSize {
         TextSize(0)
     }
 
     /// A size of one.
+    #[inline]
     pub const fn one() -> TextSize {
         TextSize(1)
     }
@@ -74,24 +77,28 @@ impl TextSize {
     /// The text size of a single ASCII character.
     pub const ONE: TextSize = TextSize(1);
 
-    #[allow(missing_docs)]
+    /// Checked addition. Returns `None` if overflow occurred.
+    #[inline]
     pub fn checked_add(self, rhs: TextSize) -> Option<TextSize> {
         self.raw.checked_add(rhs.raw).map(TextSize)
     }
 
-    #[allow(missing_docs)]
+    /// Checked subtraction. Returns `None` if overflow occurred.
+    #[inline]
     pub fn checked_sub(self, rhs: TextSize) -> Option<TextSize> {
         self.raw.checked_sub(rhs.raw).map(TextSize)
     }
 }
 
 impl From<u32> for TextSize {
+    #[inline]
     fn from(raw: u32) -> Self {
         TextSize(raw)
     }
 }
 
 impl From<TextSize> for u32 {
+    #[inline]
     fn from(value: TextSize) -> Self {
         value.raw
     }
@@ -99,12 +106,14 @@ impl From<TextSize> for u32 {
 
 impl TryFrom<usize> for TextSize {
     type Error = TryFromIntError;
+    #[inline]
     fn try_from(value: usize) -> Result<Self, TryFromIntError> {
         Ok(u32::try_from(value)?.into())
     }
 }
 
 impl From<TextSize> for usize {
+    #[inline]
     fn from(value: TextSize) -> Self {
         value.raw as usize
     }
@@ -114,12 +123,14 @@ macro_rules! ops {
     (impl $Op:ident for TextSize by fn $f:ident = $op:tt) => {
         impl $Op<TextSize> for TextSize {
             type Output = TextSize;
+            #[inline]
             fn $f(self, other: TextSize) -> TextSize {
                 TextSize(self.raw $op other.raw)
             }
         }
         impl $Op<&TextSize> for TextSize {
             type Output = TextSize;
+            #[inline]
             fn $f(self, other: &TextSize) -> TextSize {
                 self $op *other
             }
@@ -129,6 +140,7 @@ macro_rules! ops {
             TextSize: $Op<T, Output=TextSize>,
         {
             type Output = TextSize;
+            #[inline]
             fn $f(self, other: T) -> TextSize {
                 *self $op other
             }
@@ -143,6 +155,7 @@ impl<A> AddAssign<A> for TextSize
 where
     TextSize: Add<A, Output = TextSize>,
 {
+    #[inline]
     fn add_assign(&mut self, rhs: A) {
         *self = *self + rhs
     }
@@ -152,6 +165,7 @@ impl<S> SubAssign<S> for TextSize
 where
     TextSize: Sub<S, Output = TextSize>,
 {
+    #[inline]
     fn sub_assign(&mut self, rhs: S) {
         *self = *self - rhs
     }
@@ -161,6 +175,7 @@ impl<A> iter::Sum<A> for TextSize
 where
     TextSize: Add<A, Output = TextSize>,
 {
+    #[inline]
     fn sum<I: Iterator<Item = A>>(iter: I) -> TextSize {
         iter.fold(TextSize::zero(), Add::add)
     }

--- a/src/size.rs
+++ b/src/size.rs
@@ -68,8 +68,6 @@ impl TextSize {
     pub const MIN: TextSize = TextSize(u32::MIN);
     /// The largest representable text size. (`u32::MAX`)
     pub const MAX: TextSize = TextSize(u32::MAX);
-    /// The text size of a single ASCII character.
-    pub const ASCII: TextSize = TextSize(1);
 
     /// Checked addition. Returns `None` if overflow occurred.
     #[inline]

--- a/src/size.rs
+++ b/src/size.rs
@@ -59,12 +59,6 @@ impl TextSize {
     pub const fn zero() -> TextSize {
         TextSize(0)
     }
-
-    /// A size of one.
-    #[inline]
-    pub const fn one() -> TextSize {
-        TextSize(1)
-    }
 }
 
 /// Methods to act like a primitive integer type, where reasonably applicable.
@@ -75,7 +69,7 @@ impl TextSize {
     /// The largest representable text size. (`u32::MAX`)
     pub const MAX: TextSize = TextSize(u32::MAX);
     /// The text size of a single ASCII character.
-    pub const ONE: TextSize = TextSize(1);
+    pub const ASCII: TextSize = TextSize(1);
 
     /// Checked addition. Returns `None` if overflow occurred.
     #[inline]

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -6,8 +6,6 @@ pub trait TextSized: Copy {
     fn text_size(self) -> TextSize;
 }
 
-/// This will panic for strings larger than `TextSize::MAX` when
-/// debug assertions are enabled, and wrap when they are disabled.
 impl TextSized for &'_ str {
     #[inline]
     fn text_size(self) -> TextSize {

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -6,7 +6,10 @@ pub trait TextSized: Copy {
     fn text_size(self) -> TextSize;
 }
 
+/// This will panic for strings larger than `TextSize::MAX` when
+/// debug assertions are enabled, and wrap when they are disabled.
 impl TextSized for &'_ str {
+    #[inline]
     fn text_size(self) -> TextSize {
         self.len()
             .try_into()
@@ -15,6 +18,7 @@ impl TextSized for &'_ str {
 }
 
 impl TextSized for char {
+    #[inline]
     fn text_size(self) -> TextSize {
         TextSize(self.len_utf8() as u32)
     }


### PR DESCRIPTION
Because none of this was quite specific enough to break into its own PR

- Update translation docs
- Officially `compiler_error!`-forbid `cfg(target_pointer_width = "16")`
- `TextRange::before` (alt options: `TextRange::to`, `TextRange::up_to`, `TextRangeTo`, `TextSize::prefix`)
- `TextRange::after` (alt options: `TextSize::suffix`)
- `TextRange::offset` (alt options: `TextRange::add`, `Add::add`, `TextRange::reanchor`)
- `TextSize::one` (alt options: )
- `TextSize::ONE` (alt options: `TextSize::ASCII`
- `#[inline]` capability for a bunch of things

This PR is mainly just to get opinions on all of these little things, then I'll re-force-push with a commit just with those.